### PR TITLE
상점 목록 -> 상세 연결 

### DIFF
--- a/navigation/MainTabNavigator.js
+++ b/navigation/MainTabNavigator.js
@@ -25,6 +25,7 @@ const HomeStack = createStackNavigator(
   {
     Home: HomeScreen,
     StoreDetails: StoreDetails,
+    Sd: StoreDetails,
   },
   {
     initialRouteName: "Home"
@@ -54,7 +55,7 @@ const WorkingListStack = createStackNavigator({
   Yhp: YhpScreen,
   Hs: HsScreen,
   Yr: YrScreen,
-  Sd: StoreDetails,
+
 },{
   initialRouteName: "WorkingList",
 });

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -49,13 +49,14 @@ class HomeScreen extends Component {
             data={storeList}
             renderItem={({ item }) => (
               <ListItem
-                key={item.id}
+                key={item.supplier_id}
                 title={item.branch}
                 storeId={item.supplier_id}
                 subtitle={item.address}
                 rightSubtitle={parseInt(item.distance)+' m'}
                 containerElement={TouchableHighlight}
                 containerStyle={{ borderBottomColor: '#ddd', borderBottomWidth: 1 }}
+                onPress={e=>this.props.navigation.navigate('Sd', { storeId: item.supplier_id })}
               />
             )}
             keyExtractor={(item, index) => index.toString()}

--- a/screens/StoreDetails.js
+++ b/screens/StoreDetails.js
@@ -42,7 +42,7 @@ export default class StoreDetails extends React.Component {
 
   getData = () => {
     console.log("예리님이 보내준 아이디는 : ", this.state);
-    fetch(`http://54.180.153.12:8000/supplier/${this.state.id}`)
+    fetch(`http://54.180.153.12:8000/supplier/${this.state.supplier_id}`)
       .then(response => response.json())
       .catch(()=> dummyStoreData)
       .then(res =>{

--- a/screens/YrScreen.js
+++ b/screens/YrScreen.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import MapView, { Marker } from 'react-native-maps';
+import {ListItem} from "react-native-elements";
 
 export default class ListMap extends Component {
   
@@ -49,12 +50,14 @@ export default class ListMap extends Component {
         {
           storeList.map(store => (
             <Marker
+              key={store.supplier_id}
               coordinate={{
-                latitude: store.latitude,
-                longitude: store.longitude
+                latitude: +store.latitude,
+                longitude: +store.longitude
               }}
               title={store.branch}
               storeId={store.supplier_id}
+              onPress={e=>this.props.navigation.navigate('Sd', { storeId: store.supplier_id })}
             />
           ))
         }


### PR DESCRIPTION
- 상점 목록과 지도에서 클릭했을 때 상세화면으로 넘어가도록 수정
- 목록과 상세의 screen을 하나의 stack navigation으로 묶음